### PR TITLE
Re-arranging legend - Adding MBD Coin. Trigger

### DIFF
--- a/TPCEventDisplay_43865_1_ALL_CLUSTERS.json
+++ b/TPCEventDisplay_43865_1_ALL_CLUSTERS.json
@@ -1,7 +1,7 @@
 {
     "EVENT": {
         "runid":43865, 
-        "evtid": 28, 
+        "evtid": 1, 
         "time": 0, 
  "timeStr": "2024-05-25", 
        "type": "Physics", 
@@ -9,7 +9,7 @@
         "B": 0.0,
         "pv": [0,0,0],
   "runstats": [ 
-  "sPHENIX Time Projection Chamber", "2024-05-25, Run 43865 - Event 1, ZDC = 0.112 kHz",  "<i><strong> p+p  </strong></i> 200 GeV,  1.4 T"] 
+  "sPHENIX Time Projection Chamber", "2024-05-25, Run 43865 - Event 1",  "ZDC = 0.112 kHz, <i><strong> p+p  </strong></i> 200 GeV, 1.4 T Magnetic Field, MBD Coin. Trigger"] 
    },
 
     "META": {


### PR DESCRIPTION
Date: 05/25/24
Run: 43865
Event: 1
B field: 1.4 T (Full)
Trigger: MBD Coincidence
Collisions System: p+p - 200 GeV
Detector: TPC

Description:

All clusters in Event 1 of Run 43865. ZDC Rate = 0.112 kHz. Taken w/ MBD Coin. Triggers
