### PR TITLE
TPC Line Laser Event Display Run 63605 - changing angle to be correct

### DIFF
--- a/TPC_Line_laser_63605_1_3_5_5_8.json
+++ b/TPC_Line_laser_63605_1_3_5_5_8.json
@@ -15,7 +15,7 @@
         "runstats": [
             "sPHENIX Time Projection Chamber",
             "2025-05-01, Run 63605 - Events 1, 3, 4, 5, 8",
-            "Line lasers: 3S, 6S, 12S, 9S, 9N. Theta_nominal = 39, Phi_nominal = 12.75. B = 1.4 T"
+            "Line lasers: 3S, 6S, 12S, 9S, 9N. Theta_nominal = 29 deg., Phi_nominal = 338.5 deg., B = 1.4 T"
         ]
     },
     "META": {


### PR DESCRIPTION
- Angle should be phi = 338.5, theta = 29 (made it so)

